### PR TITLE
Remove cudatoolkit-dev from recipe

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,8 +8,6 @@
 # disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 #
 # *****************************************************************
-export CUDA_HOME=$PREFIX
-
 make -j src.build
 rm -rf build/obj/
 cp -R build/* $PREFIX/

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,7 +9,15 @@
 #
 # *****************************************************************
 
+## The make environment in NCCL is fairly configurable which is good
+## because we want to use the `nvcc` wrapper package in Open-CE.
+## Setting CUDA_HOME here to the conda environment will work for that. 
+## NCCL, however, also uses some static libraries from the CUDA Toolkit
+## and so we'll use it's CUDA_LIB env variable to tell it about the local
+## installation as well.
+
 export CUDA_HOME=$CONDA_PREFIX
+export CUDA_LIB=${OPEN_CE_CUDA_HOME}/lib64
  
 make -j src.build
 rm -rf build/obj/

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,16 +9,6 @@
 #
 # *****************************************************************
 
-## The make environment in NCCL is fairly configurable which is good
-## because we want to use the `nvcc` wrapper package in Open-CE.
-## Setting CUDA_HOME here to the conda environment will work for that. 
-## NCCL, however, also uses some static libraries from the CUDA Toolkit
-## and so we'll use it's CUDA_LIB env variable to tell it about the local
-## installation as well.
-
-export CUDA_HOME=$CONDA_PREFIX
-export CUDA_LIB=${OPEN_CE_CUDA_HOME}/lib64
- 
 make -j src.build
 rm -rf build/obj/
 cp -R build/* $PREFIX/

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,6 +8,9 @@
 # disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 #
 # *****************************************************************
+
+export CUDA_HOME=$CONDA_PREFIX
+ 
 make -j src.build
 rm -rf build/obj/
 cp -R build/* $PREFIX/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   git_rev: v{{ version }}-1
 
 build:
-  number: 1
+  number: 2
   string: cuda{{ cudatoolkit | replace(".*", "") }}_{{ PKG_BUILDNUM }}
   script_env:
     - OPEN_CE_CUDA_HOME

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,16 +17,16 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - {{ compiler("cuda") }}
   host:
-    - nvcc  {{ cudatoolkit }}
     - make  {{ make }}  
   run:
     - cudatoolkit  {{ cudatoolkit }}
 
 test:
   requires:
-    - cudatoolkit-dev  {{ cudatoolkit }}
     - {{ compiler('cxx') }}
+    - {{ compiler("cuda") }}
 
 about:
   home: https://github.com/NVIDIA/nccl.git

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,13 +13,12 @@ build:
   number: 2
   string: cuda{{ cudatoolkit | replace(".*", "") }}_{{ PKG_BUILDNUM }}
   script_env:
-    - OPEN_CE_CUDA_HOME
+    - CUDA_HOME
   
 requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - {{ compiler("cuda") }}
   host:
     - make  {{ make }}  
   run:
@@ -28,7 +27,6 @@ requirements:
 test:
   requires:
     - {{ compiler('cxx') }}
-    - {{ compiler("cuda") }}
 
 about:
   home: https://github.com/NVIDIA/nccl.git

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,14 +18,14 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
-    - cudatoolkit-dev   {{ cudatoolkit }}
-    - make {{ make }}  
+    - nvcc  {{ cudatoolkit }}
+    - make  {{ make }}  
   run:
-    - cudatoolkit       {{ cudatoolkit }}
+    - cudatoolkit  {{ cudatoolkit }}
 
 test:
   requires:
-    - cudatoolkit-dev   {{ cudatoolkit }}
+    - cudatoolkit-dev  {{ cudatoolkit }}
     - {{ compiler('cxx') }}
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
   number: 1
   string: cuda{{ cudatoolkit | replace(".*", "") }}_{{ PKG_BUILDNUM }}
   script_env:
-    - CUDA_HOME
+    - OPEN_CE_CUDA_HOME
   
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
   number: 1
   string: cuda{{ cudatoolkit | replace(".*", "") }}_{{ PKG_BUILDNUM }}
+  script_env:
+    - CUDA_HOME
   
 requirements:
   build:


### PR DESCRIPTION
This PR changes this recipe to use the `nvcc` meta package instead of the complete `cudatoolkit-dev` package.

requries https://github.com/open-ce/nvcc-feedstock/pull/1
requries https://github.com/open-ce/open-ce/pull/32

UPDATE:
We've decided to abandon the `nvcc` wrapper package as it was just not compatible with TensorFlow's builds. I've updated this PR to require CUDA_HOME to be set to the system installed CUDA and we'll just build against that.