### PR TITLE
Revert "refresh to V2.11.4 (#18)"

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nccl" %}
-{% set version = "2.11.4" %}
+{% set version = "2.8.3" %}
 
 package:
   name: {{ name }}
@@ -10,7 +10,7 @@ source:
   git_rev: v{{ version }}-1
 
 build:
-  number: 1
+  number: 3
   string: cuda{{ cudatoolkit | replace(".*", "") }}_{{ PKG_BUILDNUM }}
   script_env:
     - CUDA_HOME


### PR DESCRIPTION
This reverts commit f0220b8e733c594075f4960bae67945dde767c10.

## Checklist before submitting

- [X] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description
This PR reverts to NCCL v2.8.3  because all packages on main are presently built & tested with NCCL v2.8.3.
(We happen to merge PR NCCL 2.11 early.) We will put v2.11 again when we merge other PRs for OpenCE 1.5.

Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
