### PR TITLE
fix build for cuda 11.2

### DIFF
--- a/recipe/0001-fix-for-gcc-8.patch
+++ b/recipe/0001-fix-for-gcc-8.patch
@@ -1,0 +1,26 @@
+From d024a3e0e25c2a1bc23f52ca2cb91eef86041c22 Mon Sep 17 00:00:00 2001
+From: Deepali Chourasia <deepch23@in.ibm.com>
+Date: Tue, 6 Jun 2023 10:32:48 +0000
+Subject: [PATCH] fix for gcc 8
+
+---
+ src/include/nvtx3/nvtx3.hpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/include/nvtx3/nvtx3.hpp b/src/include/nvtx3/nvtx3.hpp
+index cb0ef68..1da3cd5 100644
+--- a/src/include/nvtx3/nvtx3.hpp
++++ b/src/include/nvtx3/nvtx3.hpp
+@@ -562,7 +562,8 @@
+ /* Temporary helper #defines, removed with #undef at end of header */
+ 
+ #if !defined(NVTX3_USE_CHECKED_OVERLOADS_FOR_GET)
+-#if defined(_MSC_VER) && _MSC_VER < 1914
++#if defined(_MSC_VER) && _MSC_VER < 1914 \
++  || defined(__GNUC__) && __GNUC__ == 8 && __GNUC_MINOR__ < 4
+ /* Microsoft's compiler prior to VS2017 Update 7 (15.7) uses an older parser
+  * that does not work with domain::get's specialization for domain::global,
+  * and would require extra conditions to make SFINAE work for the overloaded
+-- 
+2.34.1
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,11 @@ package:
 source:
   git_url: https://github.com/NVIDIA/nccl.git
   git_rev: v{{ version }}-1
+  patches:                           #[cudatoolkit == '11.2']
+    - 0001-fix-for-gcc-8.patch       #[cudatoolkit == '11.2']
 
 build:
-  number: 1
+  number: 2
   string: cuda{{ cudatoolkit | replace(".*", "") }}_{{ PKG_BUILDNUM }}
   script_env:
     - CUDA_HOME


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Added fix suggested in https://github.com/NVIDIA/nccl/issues/835#issuecomment-1563347391 to get build working with GCC 8 for CUDA 11.2. 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
